### PR TITLE
Update dependencies.gradle

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,7 +17,7 @@
 ext.versions = [
 
         compose        : '1.3.0-beta03',
-        minSdk         : 23,
+        minSdk         : 21,
         compileSdk     : 33,
         versionCode    : 42,
         versionName    : '1.4.1',


### PR DESCRIPTION
Can we decrease min Sdk to 21. Can not use this library in projects which supports 21 sdk devices.

First time contributing to AndroidPoet/Dropdown?
If you know how to fix an [issue](https://github.com/AndroidPoet/Dropdown/issues), consider opening a pull request for it.

You can read this repository’s contributing [guidelines](https://github.com/AndroidPoet/Dropdown/blob/master/CONTRIBUTING.md) to learn how to open a good pull request.
