### PR TITLE
feat: add disabled items support

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
-	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -54,8 +54,8 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
-	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun item (Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -153,16 +153,18 @@ public abstract interface annotation class io/androidpoet/dropdown/MenuDSL : jav
 public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IMenuItem {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)V
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;Z)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/androidpoet/dropdown/MenuItem;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)Lio/androidpoet/dropdown/MenuItem;
-	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;Z)Lio/androidpoet/dropdown/MenuItem;
+	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ZILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
+	public final fun getEnabled ()Z
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
-	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -54,8 +54,8 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
-	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun item (Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -153,16 +153,18 @@ public abstract interface annotation class io/androidpoet/dropdown/MenuDSL : jav
 public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IMenuItem {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)V
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;Z)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/androidpoet/dropdown/MenuItem;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)Lio/androidpoet/dropdown/MenuItem;
-	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;Z)Lio/androidpoet/dropdown/MenuItem;
+	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ZILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
+	public final fun getEnabled ()Z
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.ui.draw.alpha
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -154,10 +155,11 @@ public fun <T : Any> DropdownContent(
           is MenuItem -> {
             if (menuItem.hasChildren()) {
               ParentItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
+                enabled = menuItem.enabled,
                 onClick = { id ->
                   if (id != null) {
                     onChildClick(id)
@@ -166,11 +168,12 @@ public fun <T : Any> DropdownContent(
               )
             } else {
               ChildItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
-                onItemSelected,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
+                enabled = menuItem.enabled,
+                onClick = onItemSelected,
               )
             }
           }
@@ -248,15 +251,18 @@ public fun MenuItemText(
  * Wrapper for handling onClick and user interaction for a dropdown MenuItem.
  *
  * @param onClick Callback for when the MenuItem is clicked.
+ * @param enabled Whether this item is enabled (grayed out and non-interactive when false).
  * @param content The content to be displayed within the MenuItem.
  */
 @Composable
 public fun MenuItem(
   onClick: () -> Unit,
+  enabled: Boolean = true,
   content: @Composable RowScope.() -> Unit,
 ) {
   DropdownMenuItem(
     onClick = onClick,
+    enabled = enabled,
     interactionSource = remember { MutableInteractionSource() },
     text = {
       Row(
@@ -305,6 +311,7 @@ public fun CascadeHeaderItem(
  * @param title The title of the parent item.
  * @param icon The icon for the parent item.
  * @param contentColor The color of the content.
+ * @param enabled Whether this item is enabled.
  * @param onClick Callback for when the parent item is clicked.
  */
 @Composable
@@ -313,20 +320,25 @@ public fun <T> ParentItem(
   title: String,
   icon: ImageVector?,
   contentColor: Color,
+  enabled: Boolean = true,
   onClick: (T) -> Unit,
 ) {
-  MenuItem(onClick = { onClick(id) }) {
+  val alpha = if (enabled) 1f else ContentAlpha.DISABLED
+  MenuItem(
+    onClick = { if (enabled) onClick(id) },
+    enabled = enabled,
+  ) {
     if (icon != null) {
-      MenuItemIcon(icon = icon, tint = contentColor)
+      MenuItemIcon(icon = icon, tint = contentColor.copy(alpha = alpha))
       Space()
     }
     MenuItemText(
       modifier = Modifier.weight(1f),
       text = title,
-      color = contentColor,
+      color = contentColor.copy(alpha = alpha),
     )
     Space()
-    MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
+    MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor.copy(alpha = alpha))
   }
 }
 
@@ -337,6 +349,7 @@ public fun <T> ParentItem(
  * @param title The title of the child item.
  * @param icon The icon for the child item.
  * @param contentColor The color of the content.
+ * @param enabled Whether this item is enabled.
  * @param onClick Callback for when the child item is clicked.
  */
 @Composable
@@ -345,17 +358,22 @@ public fun <T> ChildItem(
   title: String,
   icon: ImageVector?,
   contentColor: Color,
+  enabled: Boolean = true,
   onClick: (T) -> Unit,
 ) {
-  MenuItem(onClick = { onClick(id) }) {
+  val alpha = if (enabled) 1f else ContentAlpha.DISABLED
+  MenuItem(
+    onClick = { if (enabled) onClick(id) },
+    enabled = enabled,
+  ) {
     if (icon != null) {
-      MenuItemIcon(icon = icon, tint = contentColor)
+      MenuItemIcon(icon = icon, tint = contentColor.copy(alpha = alpha))
       Space()
     }
     MenuItemText(
       modifier = Modifier.weight(1f),
       text = title,
-      color = contentColor,
+      color = contentColor.copy(alpha = alpha),
     )
   }
 }

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -35,6 +35,7 @@ public data class MenuItem<T : Any>(
   val id: T? = null,
   val title: String = "",
   override val parent: MenuItem<T>? = null,
+  val enabled: Boolean = true,
 ) : IMenuItem<T> {
   var icon: ImageVector? = null
   var children: MutableList<IMenuItem<T>>? = null // Note: Changed to IMenuItem
@@ -65,9 +66,10 @@ public class DropDownMenuBuilder<T : Any> {
   public fun item(
     id: T,
     title: String,
+    enabled: Boolean = true,
     init: (DropDownMenuBuilder<T>.() -> Unit)? = null,
   ) {
-    val newItem = MenuItem<T>(id, title, menu)
+    val newItem = MenuItem<T>(id, title, menu, enabled)
 
     init?.invoke(DropDownMenuBuilder<T>().apply { menu = newItem })
 


### PR DESCRIPTION
## Summary

Adds an `enabled` parameter to menu items throughout the library. Disabled items render at reduced opacity and do not respond to clicks.

## Changes

- **MenuItem** data class: added `enabled: Boolean = true` field
- **DropDownMenuBuilder.item()**: accepts `enabled` parameter with default `true`
- **MenuItem** composable: passes `enabled` to Material3's `DropdownMenuItem`
- **ParentItem / ChildItem**: respect `enabled` state with proper alpha blending
- **DropdownContent**: propagates the `enabled` flag from model to rendered composables

## Usage

```kotlin
dropDownMenu {
  item("active", "Active Item") { ... }
  item("disabled", "Disabled Item", enabled = false) {
    icon(Icons.Default.Lock)
  }
}
```

## Checklist

- [x] Compiles successfully on all targets
- [x] Binary API compatible (apiDump updated)