### PR TITLE
feat: add subtitle/description text to menu items

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -57,6 +57,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
+	public final fun subtitle (Ljava/lang/String;)V
 }
 
 public final class io/androidpoet/dropdown/DropDownMenuBuilderKt {
@@ -166,12 +167,14 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
+	public final fun setSubtitle (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -57,6 +57,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
+	public final fun subtitle (Ljava/lang/String;)V
 }
 
 public final class io/androidpoet/dropdown/DropDownMenuBuilderKt {
@@ -166,12 +167,14 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getSubtitle ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
+	public final fun setSubtitle (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -154,10 +155,11 @@ public fun <T : Any> DropdownContent(
           is MenuItem -> {
             if (menuItem.hasChildren()) {
               ParentItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
+                id = menuItem.id,
+                title = menuItem.title,
+                subtitle = menuItem.subtitle,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
                 onClick = { id ->
                   if (id != null) {
                     onChildClick(id)
@@ -166,11 +168,12 @@ public fun <T : Any> DropdownContent(
               )
             } else {
               ChildItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
-                onItemSelected,
+                id = menuItem.id,
+                title = menuItem.title,
+                subtitle = menuItem.subtitle,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
+                onClick = onItemSelected,
               )
             }
           }
@@ -303,6 +306,7 @@ public fun CascadeHeaderItem(
  *
  * @param id The ID of the parent item.
  * @param title The title of the parent item.
+ * @param subtitle Optional secondary text displayed below the title.
  * @param icon The icon for the parent item.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the parent item is clicked.
@@ -311,6 +315,7 @@ public fun CascadeHeaderItem(
 public fun <T> ParentItem(
   id: T,
   title: String,
+  subtitle: String? = null,
   icon: ImageVector?,
   contentColor: Color,
   onClick: (T) -> Unit,
@@ -320,11 +325,21 @@ public fun <T> ParentItem(
       MenuItemIcon(icon = icon, tint = contentColor)
       Space()
     }
-    MenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
+    Column(modifier = Modifier.weight(1f)) {
+      MenuItemText(
+        modifier = Modifier,
+        text = title,
+        color = contentColor,
+      )
+      if (subtitle != null) {
+        Text(
+          text = subtitle,
+          style = MaterialTheme.typography.labelSmall,
+          color = contentColor.copy(alpha = ContentAlpha.MEDIUM),
+          fontWeight = FontWeight.Normal,
+        )
+      }
+    }
     Space()
     MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
   }
@@ -335,6 +350,7 @@ public fun <T> ParentItem(
  *
  * @param id The ID of the child item.
  * @param title The title of the child item.
+ * @param subtitle Optional secondary text displayed below the title.
  * @param icon The icon for the child item.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the child item is clicked.
@@ -343,6 +359,7 @@ public fun <T> ParentItem(
 public fun <T> ChildItem(
   id: T,
   title: String,
+  subtitle: String? = null,
   icon: ImageVector?,
   contentColor: Color,
   onClick: (T) -> Unit,
@@ -352,11 +369,21 @@ public fun <T> ChildItem(
       MenuItemIcon(icon = icon, tint = contentColor)
       Space()
     }
-    MenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
+    Column(modifier = Modifier.weight(1f)) {
+      MenuItemText(
+        modifier = Modifier,
+        text = title,
+        color = contentColor,
+      )
+      if (subtitle != null) {
+        Text(
+          text = subtitle,
+          style = MaterialTheme.typography.labelSmall,
+          color = contentColor.copy(alpha = ContentAlpha.MEDIUM),
+          fontWeight = FontWeight.Normal,
+        )
+      }
+    }
   }
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -37,6 +37,7 @@ public data class MenuItem<T : Any>(
   override val parent: MenuItem<T>? = null,
 ) : IMenuItem<T> {
   var icon: ImageVector? = null
+  var subtitle: String? = null
   var children: MutableList<IMenuItem<T>>? = null // Note: Changed to IMenuItem
 
   public fun hasChildren(): Boolean = !children.isNullOrEmpty()
@@ -53,6 +54,10 @@ public class DropDownMenuBuilder<T : Any> {
 
   public fun icon(value: ImageVector) {
     menu.icon = value
+  }
+
+  public fun subtitle(value: String) {
+    menu.subtitle = value
   }
 
   public fun horizontalDivider() {


### PR DESCRIPTION
## Summary

Adds optional secondary description text rendered below the title on menu items.

## Changes

- **MenuItem**: added mutable `subtitle: String?` field
- **DropDownMenuBuilder**: added `subtitle()` DSL function
- **ChildItem / ParentItem**: accept optional `subtitle` param and render it via `labelSmall` typography at reduced alpha
- **DropdownContent**: passes `menuItem.subtitle` through to item composables

## Usage

```kotlin
dropDownMenu {
  item("storage", "Storage Settings") {
    subtitle("Manage app storage and cache")
    icon(Icons.Default.Storage)
  }
}
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)