### PR TITLE
feat: add badge/notification count support to menu items

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -37,13 +37,14 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/Integer;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MenuItemBadge-RPmYEkk (IJLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/Integer;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -51,6 +52,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun badge (I)V
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
@@ -161,6 +163,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)Lio/androidpoet/dropdown/MenuItem;
 	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBadge ()Ljava/lang/Integer;
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
@@ -170,6 +173,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
+	public final fun setBadge (Ljava/lang/Integer;)V
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -37,13 +37,14 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/Integer;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MenuItemBadge-RPmYEkk (IJLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-FHprtrg (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/Integer;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -51,6 +52,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun badge (I)V
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
@@ -161,6 +163,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)Lio/androidpoet/dropdown/MenuItem;
 	public static synthetic fun copy$default (Lio/androidpoet/dropdown/MenuItem;Ljava/lang/Object;Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILjava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBadge ()Ljava/lang/Integer;
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
@@ -170,6 +173,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
+	public final fun setBadge (Ljava/lang/Integer;)V
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -21,13 +21,16 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowLeft
 import androidx.compose.material.icons.automirrored.rounded.ArrowRight
@@ -46,9 +49,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * [Dropdown] is a DropdownMenu wrapper class to add cascade effect and animations.
@@ -154,10 +160,11 @@ public fun <T : Any> DropdownContent(
           is MenuItem -> {
             if (menuItem.hasChildren()) {
               ParentItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                badge = menuItem.badge,
+                contentColor = colors.contentColor,
                 onClick = { id ->
                   if (id != null) {
                     onChildClick(id)
@@ -166,11 +173,12 @@ public fun <T : Any> DropdownContent(
               )
             } else {
               ChildItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
-                onItemSelected,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                badge = menuItem.badge,
+                contentColor = colors.contentColor,
+                onClick = onItemSelected,
               )
             }
           }
@@ -245,6 +253,38 @@ public fun MenuItemText(
 }
 
 /**
+ * Displays a numeric badge indicator for a MenuItem.
+ *
+ * @param count The number to display in the badge.
+ * @param tint The color of the badge text and background.
+ */
+@Composable
+public fun MenuItemBadge(
+  count: Int,
+  tint: Color,
+) {
+  val badgeText = if (count > 99) "99+" else count.toString()
+  Box(
+    modifier = Modifier
+      .size(20.dp)
+      .background(
+        color = tint.copy(alpha = 0.15f),
+        shape = CircleShape,
+      ),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = badgeText,
+      style = MaterialTheme.typography.labelSmall,
+      fontSize = 10.sp,
+      fontWeight = FontWeight.Bold,
+      color = tint,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+/**
  * Wrapper for handling onClick and user interaction for a dropdown MenuItem.
  *
  * @param onClick Callback for when the MenuItem is clicked.
@@ -304,6 +344,7 @@ public fun CascadeHeaderItem(
  * @param id The ID of the parent item.
  * @param title The title of the parent item.
  * @param icon The icon for the parent item.
+ * @param badge Optional numeric badge to display on the item.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the parent item is clicked.
  */
@@ -312,6 +353,7 @@ public fun <T> ParentItem(
   id: T,
   title: String,
   icon: ImageVector?,
+  badge: Int? = null,
   contentColor: Color,
   onClick: (T) -> Unit,
 ) {
@@ -325,7 +367,11 @@ public fun <T> ParentItem(
       text = title,
       color = contentColor,
     )
-    Space()
+    if (badge != null) {
+      Spacer(modifier = Modifier.width(8.dp))
+      MenuItemBadge(count = badge, tint = contentColor)
+      Space()
+    }
     MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
   }
 }
@@ -336,6 +382,7 @@ public fun <T> ParentItem(
  * @param id The ID of the child item.
  * @param title The title of the child item.
  * @param icon The icon for the child item.
+ * @param badge Optional numeric badge to display on the item.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the child item is clicked.
  */
@@ -344,6 +391,7 @@ public fun <T> ChildItem(
   id: T,
   title: String,
   icon: ImageVector?,
+  badge: Int? = null,
   contentColor: Color,
   onClick: (T) -> Unit,
 ) {
@@ -357,6 +405,10 @@ public fun <T> ChildItem(
       text = title,
       color = contentColor,
     )
+    if (badge != null) {
+      Spacer(modifier = Modifier.width(8.dp))
+      MenuItemBadge(count = badge, tint = contentColor)
+    }
   }
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -37,6 +37,7 @@ public data class MenuItem<T : Any>(
   override val parent: MenuItem<T>? = null,
 ) : IMenuItem<T> {
   var icon: ImageVector? = null
+  var badge: Int? = null
   var children: MutableList<IMenuItem<T>>? = null // Note: Changed to IMenuItem
 
   public fun hasChildren(): Boolean = !children.isNullOrEmpty()
@@ -53,6 +54,10 @@ public class DropDownMenuBuilder<T : Any> {
 
   public fun icon(value: ImageVector) {
     menu.icon = value
+  }
+
+  public fun badge(value: Int) {
+    menu.badge = value
   }
 
   public fun horizontalDivider() {


### PR DESCRIPTION
## Summary

Adds an optional numeric badge indicator on menu items (e.g. for notification counts).

## Changes

- **MenuItem**: added mutable `badge: Int?` field
- **DropDownMenuBuilder**: added `badge()` DSL function
- **MenuItemBadge**: new composable rendering a circular badge (caps at `99+`)
- **ParentItem / ChildItem**: render badge when present with proper spacing
- **DropdownContent**: propagates badge from model to item composables

## Usage

```kotlin
dropDownMenu {
  item("notifications", "Notifications") {
    icon(Icons.Default.Notifications)
    badge(12)
  }
}
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)