### PR TITLE
feat: add section headers for grouping menu items

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -44,6 +44,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
 	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun SectionHeader-RPmYEkk (Ljava/lang/String;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -56,6 +57,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun section (Ljava/lang/String;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -173,5 +175,13 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/SectionHeaderItem : io/androidpoet/dropdown/IMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getTitle ()Ljava/lang/String;
 }
 

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -44,6 +44,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
 	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun SectionHeader-RPmYEkk (Ljava/lang/String;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -56,6 +57,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun section (Ljava/lang/String;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -173,5 +175,13 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/SectionHeaderItem : io/androidpoet/dropdown/IMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getTitle ()Ljava/lang/String;
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -46,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -175,6 +177,13 @@ public fun <T : Any> DropdownContent(
             }
           }
 
+          is SectionHeaderItem -> {
+            SectionHeader(
+              title = menuItem.title,
+              contentColor = colors.contentColor,
+            )
+          }
+
           is Divider -> {
             HorizontalDivider(
               modifier = Modifier.fillMaxWidth(),
@@ -185,6 +194,29 @@ public fun <T : Any> DropdownContent(
       }
     }
   }
+}
+
+/**
+ * Displays a section header label within the dropdown menu.
+ *
+ * @param title The title text for the section.
+ * @param contentColor The color of the content.
+ */
+@Composable
+public fun SectionHeader(
+  title: String,
+  contentColor: Color,
+) {
+  Text(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 12.dp, vertical = 6.dp),
+    text = title.uppercase(),
+    style = MaterialTheme.typography.labelSmall,
+    fontWeight = FontWeight.SemiBold,
+    color = contentColor.copy(alpha = ContentAlpha.MEDIUM),
+    maxLines = 1,
+  )
 }
 
 /**

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -30,6 +30,13 @@ public sealed interface IMenuItem<T : Any> {
 @MenuDSL
 public class Divider<T : Any>(override val parent: MenuItem<T>? = null) : IMenuItem<T>
 
+// Represent a section header as a special menu item
+@MenuDSL
+public class SectionHeaderItem<T : Any>(
+  public val title: String,
+  override val parent: MenuItem<T>? = null,
+) : IMenuItem<T>
+
 @MenuDSL
 public data class MenuItem<T : Any>(
   val id: T? = null,
@@ -60,6 +67,13 @@ public class DropDownMenuBuilder<T : Any> {
       menu.children = mutableListOf()
     }
     menu.children?.add(Divider(menu))
+  }
+
+  public fun section(title: String) {
+    if (menu.children == null) {
+      menu.children = mutableListOf()
+    }
+    menu.children?.add(SectionHeaderItem(title, menu))
   }
 
   public fun item(


### PR DESCRIPTION
## Summary

Adds visual section headers to group related menu items, similar to iOS/Android settings menus.

## Changes

- **SectionHeaderItem**: new class implementing IMenuItem with a title
- **DropDownMenuBuilder.section()**: DSL function to add a header
- **SectionHeader**: composable rendering uppercase label with semi-bold weight
- **DropdownContent**: renders SectionHeaderItem in the when block

## Usage

```kotlin
dropDownMenu {
  section("Account")
  item("profile", "Profile") { ... }
  item("settings", "Settings") { ... }
  section("Actions")
  item("logout", "Logout") { ... }
}
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)