### PR TITLE
feat: add RTL layout support for dropdown arrows

### DIFF
--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -46,8 +46,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
@@ -283,9 +285,15 @@ public fun CascadeHeaderItem(
   contentColor: Color,
   onClick: () -> Unit,
 ) {
+  val layoutDirection = LocalLayoutDirection.current
+  val backIcon = if (layoutDirection == LayoutDirection.Ltr) {
+    Icons.AutoMirrored.Rounded.ArrowLeft
+  } else {
+    Icons.AutoMirrored.Rounded.ArrowRight
+  }
   MenuItem(onClick = { onClick() }) {
     MenuItemIcon(
-      icon = Icons.AutoMirrored.Rounded.ArrowLeft,
+      icon = backIcon,
       tint = contentColor.copy(alpha = ContentAlpha.MEDIUM),
     )
     Spacer(modifier = Modifier.width(4.dp))
@@ -315,6 +323,12 @@ public fun <T> ParentItem(
   contentColor: Color,
   onClick: (T) -> Unit,
 ) {
+  val layoutDirection = LocalLayoutDirection.current
+  val forwardIcon = if (layoutDirection == LayoutDirection.Ltr) {
+    Icons.AutoMirrored.Rounded.ArrowRight
+  } else {
+    Icons.AutoMirrored.Rounded.ArrowLeft
+  }
   MenuItem(onClick = { onClick(id) }) {
     if (icon != null) {
       MenuItemIcon(icon = icon, tint = contentColor)
@@ -326,7 +340,7 @@ public fun <T> ParentItem(
       color = contentColor,
     )
     Space()
-    MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
+    MenuItemIcon(icon = forwardIcon, tint = contentColor)
   }
 }
 


### PR DESCRIPTION
## Summary

Makes the cascade navigation arrows automatically mirror in right-to-left locales by respecting .

## Changes

- **CascadeHeaderItem**: back arrow switches to ArrowRight in RTL
- **ParentItem**: forward arrow switches to ArrowLeft in RTL
- Uses  to detect current layout direction

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)