### PR TITLE
feat: add custom composable content per menu item

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -51,6 +51,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun content (Lkotlin/jvm/functions/Function3;)V
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
@@ -163,6 +164,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
+	public final fun getCustomContent ()Lkotlin/jvm/functions/Function3;
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
@@ -171,6 +173,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
+	public final fun setCustomContent (Lkotlin/jvm/functions/Function3;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-fWhpE4E (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -51,6 +51,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public static final field $stable I
 	public fun <init> ()V
+	public final fun content (Lkotlin/jvm/functions/Function3;)V
 	public final fun getMenu ()Lio/androidpoet/dropdown/MenuItem;
 	public final fun horizontalDivider ()V
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
@@ -163,6 +164,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChild (Ljava/lang/Object;)Lio/androidpoet/dropdown/MenuItem;
 	public final fun getChildren ()Ljava/util/List;
+	public final fun getCustomContent ()Lkotlin/jvm/functions/Function3;
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
@@ -171,6 +173,7 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
+	public final fun setCustomContent (Lkotlin/jvm/functions/Function3;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -154,10 +154,11 @@ public fun <T : Any> DropdownContent(
           is MenuItem -> {
             if (menuItem.hasChildren()) {
               ParentItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
+                customContent = menuItem.customContent,
                 onClick = { id ->
                   if (id != null) {
                     onChildClick(id)
@@ -166,11 +167,12 @@ public fun <T : Any> DropdownContent(
               )
             } else {
               ChildItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
-                onItemSelected,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                contentColor = colors.contentColor,
+                customContent = menuItem.customContent,
+                onClick = onItemSelected,
               )
             }
           }
@@ -305,6 +307,7 @@ public fun CascadeHeaderItem(
  * @param title The title of the parent item.
  * @param icon The icon for the parent item.
  * @param contentColor The color of the content.
+ * @param customContent Optional custom composable content for this item.
  * @param onClick Callback for when the parent item is clicked.
  */
 @Composable
@@ -313,20 +316,25 @@ public fun <T> ParentItem(
   title: String,
   icon: ImageVector?,
   contentColor: Color,
+  customContent: (@Composable RowScope.() -> Unit)? = null,
   onClick: (T) -> Unit,
 ) {
   MenuItem(onClick = { onClick(id) }) {
-    if (icon != null) {
-      MenuItemIcon(icon = icon, tint = contentColor)
+    if (customContent != null) {
+      customContent()
+    } else {
+      if (icon != null) {
+        MenuItemIcon(icon = icon, tint = contentColor)
+        Space()
+      }
+      MenuItemText(
+        modifier = Modifier.weight(1f),
+        text = title,
+        color = contentColor,
+      )
       Space()
+      MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
     }
-    MenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
-    Space()
-    MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
   }
 }
 
@@ -337,6 +345,7 @@ public fun <T> ParentItem(
  * @param title The title of the child item.
  * @param icon The icon for the child item.
  * @param contentColor The color of the content.
+ * @param customContent Optional custom composable content for this item.
  * @param onClick Callback for when the child item is clicked.
  */
 @Composable
@@ -345,18 +354,23 @@ public fun <T> ChildItem(
   title: String,
   icon: ImageVector?,
   contentColor: Color,
+  customContent: (@Composable RowScope.() -> Unit)? = null,
   onClick: (T) -> Unit,
 ) {
   MenuItem(onClick = { onClick(id) }) {
-    if (icon != null) {
-      MenuItemIcon(icon = icon, tint = contentColor)
-      Space()
+    if (customContent != null) {
+      customContent()
+    } else {
+      if (icon != null) {
+        MenuItemIcon(icon = icon, tint = contentColor)
+        Space()
+      }
+      MenuItemText(
+        modifier = Modifier.weight(1f),
+        text = title,
+        color = contentColor,
+      )
     }
-    MenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
   }
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -15,6 +15,8 @@
  */
 package io.androidpoet.dropdown
 
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 
 @DslMarker
@@ -37,6 +39,7 @@ public data class MenuItem<T : Any>(
   override val parent: MenuItem<T>? = null,
 ) : IMenuItem<T> {
   var icon: ImageVector? = null
+  var customContent: (@Composable RowScope.() -> Unit)? = null
   var children: MutableList<IMenuItem<T>>? = null // Note: Changed to IMenuItem
 
   public fun hasChildren(): Boolean = !children.isNullOrEmpty()
@@ -53,6 +56,10 @@ public class DropDownMenuBuilder<T : Any> {
 
   public fun icon(value: ImageVector) {
     menu.icon = value
+  }
+
+  public fun content(value: @Composable RowScope.() -> Unit) {
+    menu.customContent = value
   }
 
   public fun horizontalDivider() {


### PR DESCRIPTION
## Summary

Allows users to supply arbitrary `@Composable RowScope.() -> Unit` content for any menu item, enabling rich custom layouts beyond the default icon+text.

## Changes

- **MenuItem**: added mutable `customContent: (@Composable RowScope.() -> Unit)?` field
- **DropDownMenuBuilder.content()**: DSL function to set custom content
- **ChildItem / ParentItem**: renders custom content when present, falls back to default layout
- **DropdownContent**: propagates customContent from model to composables

## Usage

```kotlin
dropDownMenu {
  item("profile", "Profile") {
    content {
      Icon(Icons.Default.Person, null, tint = contentColor)
      Spacer(Modifier.width(8.dp))
      Column(Modifier.weight(1f)) {
        Text("Ranbir Singh", style = ...)
        Text("@androidpoet", style = ...)
      }
    }
  }
}
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)