### PR TITLE
feat: add theme presets for DropDownMenuColors

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -65,6 +65,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilderKt {
 
 public final class io/androidpoet/dropdown/DropDownMenuColors {
 	public static final field $stable I
+	public static final field Companion Lio/androidpoet/dropdown/DropDownMenuColors$Companion;
 	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
@@ -75,6 +76,13 @@ public final class io/androidpoet/dropdown/DropDownMenuColors {
 	public final fun getContentColor-0d7_KjU ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/DropDownMenuColors$Companion {
+	public final fun dark (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun default (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun minimal (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun primary (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
 }
 
 public final class io/androidpoet/dropdown/Easing : java/lang/Enum {

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -65,6 +65,7 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilderKt {
 
 public final class io/androidpoet/dropdown/DropDownMenuColors {
 	public static final field $stable I
+	public static final field Companion Lio/androidpoet/dropdown/DropDownMenuColors$Companion;
 	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
@@ -75,6 +76,13 @@ public final class io/androidpoet/dropdown/DropDownMenuColors {
 	public final fun getContentColor-0d7_KjU ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/DropDownMenuColors$Companion {
+	public final fun dark (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun default (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun minimal (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
+	public final fun primary (Landroidx/compose/runtime/Composer;I)Lio/androidpoet/dropdown/DropDownMenuColors;
 }
 
 public final class io/androidpoet/dropdown/Easing : java/lang/Enum {

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/MenuColors.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/MenuColors.kt
@@ -23,7 +23,34 @@ import androidx.compose.ui.graphics.Color
 public data class DropDownMenuColors(
   val backgroundColor: Color,
   val contentColor: Color,
-)
+) {
+  public companion object {
+    /** Uses the theme's surface color (default). */
+    @Composable
+    public fun default(): DropDownMenuColors = dropDownMenuColors()
+
+    /** Dark theme preset with elevated surface and inverted content. */
+    @Composable
+    public fun dark(): DropDownMenuColors = DropDownMenuColors(
+      backgroundColor = Color(0xFF2D2D2D),
+      contentColor = Color(0xFFE0E0E0),
+    )
+
+    /** Minimal light preset with very subtle styling. */
+    @Composable
+    public fun minimal(): DropDownMenuColors = DropDownMenuColors(
+      backgroundColor = Color(0xFFF8F8F8),
+      contentColor = Color(0xFF333333),
+    )
+
+    /** Uses the theme's primary color as background with matching content. */
+    @Composable
+    public fun primary(): DropDownMenuColors = DropDownMenuColors(
+      backgroundColor = MaterialTheme.colorScheme.primary,
+      contentColor = MaterialTheme.colorScheme.onPrimary,
+    )
+  }
+}
 
 public object ContentAlpha {
   public const val HIGH: Float = 1.0f


### PR DESCRIPTION
## Summary

Adds built-in theme presets as companion functions on DropDownMenuColors for quick styling.

## Presets

- **default()** — theme surface/onSurface (standard)
- **dark()** — dark elevated surface (#2D2D2D) with light text
- **minimal()** — very light background (#F8F8F8) with dark text
- **primary()** — uses MaterialTheme primary/onPrimary colors

## Usage

```kotlin
Dropdown(
  colors = DropDownMenuColors.dark(),
  ...
)
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)