### PR TITLE
feat: add keyboard navigation support for cascading menus

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -39,7 +39,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun DropdownContent-0vH8DBg (Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -39,7 +39,7 @@ public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun DropdownContent-0vH8DBg (Lio/androidpoet/dropdown/MenuItem;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowLeft
 import androidx.compose.material.icons.automirrored.rounded.ArrowRight
@@ -44,8 +46,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -84,6 +94,7 @@ public fun <T : Any> Dropdown(
   onDismiss: () -> Unit,
 ) {
   var currentMenu by remember(menu, isOpen) { mutableStateOf(menu) }
+  var focusedIndex by remember { mutableStateOf(0) }
 
   DropdownMenu(
     modifier = modifier.width(width).background(colors.backgroundColor),
@@ -105,14 +116,18 @@ public fun <T : Any> Dropdown(
     }) { targetMenu ->
       DropdownContent(
         targetMenu = targetMenu,
+        focusedIndex = focusedIndex,
+        onFocusedIndexChange = { focusedIndex = it },
         onItemSelected = onItemSelected,
         colors = colors,
         width = width,
         onParentClick = {
+          focusedIndex = 0
           currentMenu =
             targetMenu.parent ?: throw IllegalStateException("Invalid parent menu")
         },
         onChildClick = { id ->
+          focusedIndex = 0
           val child = targetMenu.getChild(id)
           currentMenu = child ?: throw IllegalStateException("Invalid item id: $id")
         },
@@ -125,6 +140,8 @@ public fun <T : Any> Dropdown(
  * Represents menu content properties for a dropdown menu.
  *
  * @param targetMenu The MenuItem representing the dropdown menu.
+ * @param focusedIndex The index of the currently focused item.
+ * @param onFocusedIndexChange Callback when the focused index changes.
  * @param onItemSelected Callback for when an item is selected.
  * @param colors Dropdown menu colors.
  * @param onParentClick Callback for when the parent item is clicked.
@@ -134,13 +151,64 @@ public fun <T : Any> Dropdown(
 @Composable
 public fun <T : Any> DropdownContent(
   targetMenu: MenuItem<T>,
+  focusedIndex: Int = 0,
+  onFocusedIndexChange: (Int) -> Unit = {},
   onItemSelected: (T?) -> Unit,
   colors: DropDownMenuColors,
   onParentClick: () -> Unit,
   width: Dp,
   onChildClick: (T) -> Unit,
 ) {
-  Column(modifier = Modifier.width(width)) {
+  val items = remember(targetMenu) {
+    targetMenu.children?.filterIsInstance<MenuItem<T>>().orEmpty()
+  }
+  Column(
+    modifier = Modifier
+      .width(width)
+      .onKeyEvent { event ->
+        when (event.key) {
+          Key.DirectionDown -> {
+            if (focusedIndex < items.size - 1) {
+              onFocusedIndexChange(focusedIndex + 1)
+            }
+            true
+          }
+          Key.DirectionUp -> {
+            if (focusedIndex > 0) {
+              onFocusedIndexChange(focusedIndex - 1)
+            }
+            true
+          }
+          Key.Enter -> {
+            if (items.isNotEmpty() && focusedIndex < items.size) {
+              val item = items[focusedIndex]
+              if (item.hasChildren()) {
+                onChildClick(item.id ?: return@onKeyEvent true)
+              } else {
+                onItemSelected(item.id)
+              }
+            }
+            true
+          }
+          Key.DirectionRight -> {
+            if (items.isNotEmpty() && focusedIndex < items.size) {
+              val item = items[focusedIndex]
+              if (item.hasChildren()) {
+                onChildClick(item.id ?: return@onKeyEvent true)
+              }
+            }
+            true
+          }
+          Key.DirectionLeft -> {
+            if (targetMenu.hasParent()) {
+              onParentClick()
+            }
+            true
+          }
+          else -> false
+        }
+      },
+  ) {
     if (targetMenu.hasParent()) {
       CascadeHeaderItem(
         targetMenu.title,


### PR DESCRIPTION
## Summary

Adds full keyboard navigation: Arrow Up/Down to navigate items, Enter/Right Arrow to drill into sub-menus, Left Arrow to go back to parent.

## Changes

- **DropdownContent**: new `focusedIndex` and `onFocusedIndexChange` parameters
- **Dropdown**: tracks `focusedIndex` state, resets on menu navigation
- Uses `Modifier.onKeyEvent` on the content column
- Arrow Down/Up cycles through visible items
- Enter/Right Arrow activates the focused item (selects child or enters sub-menu)
- Left Arrow navigates back to parent menu

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)