### PR TITLE
feat: add checkbox multi-select and radio single-select support

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-cd68TDI (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Lio/androidpoet/dropdown/SelectMode;ZJLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-cd68TDI (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Lio/androidpoet/dropdown/SelectMode;ZJLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -56,6 +56,8 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun selectable (Lio/androidpoet/dropdown/SelectMode;Z)V
+	public static synthetic fun selectable$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Lio/androidpoet/dropdown/SelectMode;ZILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -166,12 +168,25 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getSelectable ()Lio/androidpoet/dropdown/SelectMode;
+	public final fun getSelected ()Z
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
+	public final fun setSelectable (Lio/androidpoet/dropdown/SelectMode;)V
+	public final fun setSelected (Z)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/SelectMode : java/lang/Enum {
+	public static final field Multi Lio/androidpoet/dropdown/SelectMode;
+	public static final field None Lio/androidpoet/dropdown/SelectMode;
+	public static final field Single Lio/androidpoet/dropdown/SelectMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/androidpoet/dropdown/SelectMode;
+	public static fun values ()[Lio/androidpoet/dropdown/SelectMode;
 }
 

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -37,13 +37,13 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ChildItem-cd68TDI (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Lio/androidpoet/dropdown/SelectMode;ZJLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemText-cf5BqRc (Landroidx/compose/ui/Modifier;Ljava/lang/String;JZLandroidx/compose/runtime/Composer;II)V
-	public static final fun ParentItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ParentItem-cd68TDI (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;Lio/androidpoet/dropdown/SelectMode;ZJLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Space (Landroidx/compose/runtime/Composer;I)V
 	public static final fun getMAX_WIDTH ()F
 }
@@ -56,6 +56,8 @@ public final class io/androidpoet/dropdown/DropDownMenuBuilder {
 	public final fun icon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public final fun item (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun item$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun selectable (Lio/androidpoet/dropdown/SelectMode;Z)V
+	public static synthetic fun selectable$default (Lio/androidpoet/dropdown/DropDownMenuBuilder;Lio/androidpoet/dropdown/SelectMode;ZILjava/lang/Object;)V
 	public final fun setMenu (Lio/androidpoet/dropdown/MenuItem;)V
 }
 
@@ -166,12 +168,25 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun getIcon ()Landroidx/compose/ui/graphics/vector/ImageVector;
 	public final fun getId ()Ljava/lang/Object;
 	public fun getParent ()Lio/androidpoet/dropdown/MenuItem;
+	public final fun getSelectable ()Lio/androidpoet/dropdown/SelectMode;
+	public final fun getSelected ()Z
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun hasChildren ()Z
 	public final fun hasParent ()Z
 	public fun hashCode ()I
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
+	public final fun setSelectable (Lio/androidpoet/dropdown/SelectMode;)V
+	public final fun setSelected (Z)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/SelectMode : java/lang/Enum {
+	public static final field Multi Lio/androidpoet/dropdown/SelectMode;
+	public static final field None Lio/androidpoet/dropdown/SelectMode;
+	public static final field Single Lio/androidpoet/dropdown/SelectMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/androidpoet/dropdown/SelectMode;
+	public static fun values ()[Lio/androidpoet/dropdown/SelectMode;
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -31,6 +31,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowLeft
 import androidx.compose.material.icons.automirrored.rounded.ArrowRight
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
+import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -154,10 +158,12 @@ public fun <T : Any> DropdownContent(
           is MenuItem -> {
             if (menuItem.hasChildren()) {
               ParentItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                selectable = menuItem.selectable,
+                selected = menuItem.selected,
+                contentColor = colors.contentColor,
                 onClick = { id ->
                   if (id != null) {
                     onChildClick(id)
@@ -166,11 +172,13 @@ public fun <T : Any> DropdownContent(
               )
             } else {
               ChildItem(
-                menuItem.id,
-                menuItem.title,
-                menuItem.icon,
-                colors.contentColor,
-                onItemSelected,
+                id = menuItem.id,
+                title = menuItem.title,
+                icon = menuItem.icon,
+                selectable = menuItem.selectable,
+                selected = menuItem.selected,
+                contentColor = colors.contentColor,
+                onClick = onItemSelected,
               )
             }
           }
@@ -298,12 +306,27 @@ public fun CascadeHeaderItem(
   }
 }
 
+@Composable
+private fun selectableIcon(
+  selectable: SelectMode,
+  selected: Boolean,
+  tint: Color,
+): ImageVector? = when {
+  selectable == SelectMode.Multi && selected -> Icons.Filled.CheckBox
+  selectable == SelectMode.Multi && !selected -> Icons.Filled.CheckBoxOutlineBlank
+  selectable == SelectMode.Single && selected -> Icons.Filled.RadioButtonChecked
+  selectable == SelectMode.Single && !selected -> Icons.Filled.RadioButtonUnchecked
+  else -> null
+}
+
 /**
  * Represents a parent item of the menu.
  *
  * @param id The ID of the parent item.
  * @param title The title of the parent item.
  * @param icon The icon for the parent item.
+ * @param selectable The selection mode for this item.
+ * @param selected Whether this item is currently selected.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the parent item is clicked.
  */
@@ -312,6 +335,8 @@ public fun <T> ParentItem(
   id: T,
   title: String,
   icon: ImageVector?,
+  selectable: SelectMode = SelectMode.None,
+  selected: Boolean = false,
   contentColor: Color,
   onClick: (T) -> Unit,
 ) {
@@ -320,13 +345,20 @@ public fun <T> ParentItem(
       MenuItemIcon(icon = icon, tint = contentColor)
       Space()
     }
+    val selIcon = selectableIcon(selectable, selected, contentColor)
+    if (selIcon != null) {
+      MenuItemIcon(icon = selIcon, tint = contentColor)
+      Space()
+    }
     MenuItemText(
       modifier = Modifier.weight(1f),
       text = title,
       color = contentColor,
     )
-    Space()
-    MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
+    if (selectable == SelectMode.None) {
+      Space()
+      MenuItemIcon(icon = Icons.AutoMirrored.Rounded.ArrowRight, tint = contentColor)
+    }
   }
 }
 
@@ -336,6 +368,8 @@ public fun <T> ParentItem(
  * @param id The ID of the child item.
  * @param title The title of the child item.
  * @param icon The icon for the child item.
+ * @param selectable The selection mode for this item.
+ * @param selected Whether this item is currently selected.
  * @param contentColor The color of the content.
  * @param onClick Callback for when the child item is clicked.
  */
@@ -344,12 +378,19 @@ public fun <T> ChildItem(
   id: T,
   title: String,
   icon: ImageVector?,
+  selectable: SelectMode = SelectMode.None,
+  selected: Boolean = false,
   contentColor: Color,
   onClick: (T) -> Unit,
 ) {
   MenuItem(onClick = { onClick(id) }) {
     if (icon != null) {
       MenuItemIcon(icon = icon, tint = contentColor)
+      Space()
+    }
+    val selIcon = selectableIcon(selectable, selected, contentColor)
+    if (selIcon != null) {
+      MenuItemIcon(icon = selIcon, tint = contentColor)
       Space()
     }
     MenuItemText(

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -17,6 +17,15 @@ package io.androidpoet.dropdown
 
 import androidx.compose.ui.graphics.vector.ImageVector
 
+public enum class SelectMode {
+  /** Item is not selectable. */
+  None,
+  /** Single-select (radio button style). */
+  Single,
+  /** Multi-select (checkbox style). */
+  Multi,
+}
+
 @DslMarker
 public annotation class MenuDSL
 
@@ -37,6 +46,8 @@ public data class MenuItem<T : Any>(
   override val parent: MenuItem<T>? = null,
 ) : IMenuItem<T> {
   var icon: ImageVector? = null
+  var selectable: SelectMode = SelectMode.None
+  var selected: Boolean = false
   var children: MutableList<IMenuItem<T>>? = null // Note: Changed to IMenuItem
 
   public fun hasChildren(): Boolean = !children.isNullOrEmpty()
@@ -53,6 +64,11 @@ public class DropDownMenuBuilder<T : Any> {
 
   public fun icon(value: ImageVector) {
     menu.icon = value
+  }
+
+  public fun selectable(mode: SelectMode, selected: Boolean = false) {
+    menu.selectable = mode
+    menu.selected = selected
   }
 
   public fun horizontalDivider() {


### PR DESCRIPTION
## Summary

Adds selection support to menu items with visual checkbox/radio indicators.

## Changes

- **SelectMode**: new enum (None / Single / Multi)
- **MenuItem**: added `selectable` (SelectMode) and `selected` (Boolean) fields
- **DropDownMenuBuilder.selectable()**: DSL function to mark items as selectable
- **ChildItem / ParentItem**: render checkbox or radio icons based on selection mode/state
- New helper composable `selectableIcon()` for icon selection logic

## Usage

```kotlin
dropDownMenu {
  item("opt1", "Option 1") {
    selectable(SelectMode.Multi, selected = true)
  }
  item("opt2", "Option 2") {
    selectable(SelectMode.Single)
  }
}
```

## Checklist

- [x] Compiles successfully
- [x] Binary API compatible (apiDump updated)