### PR TITLE
feat: add MenuPlacement enum with dynamic positioning support

### DIFF
--- a/dropdown/api/android/dropdown.api
+++ b/dropdown/api/android/dropdown.api
@@ -38,7 +38,7 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
-	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Dropdown-u0eclSw (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/MenuPlacement;Lio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
@@ -173,5 +173,16 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/MenuPlacement : java/lang/Enum {
+	public static final field Auto Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Down Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field End Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Start Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Up Lio/androidpoet/dropdown/MenuPlacement;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/androidpoet/dropdown/MenuPlacement;
+	public static fun values ()[Lio/androidpoet/dropdown/MenuPlacement;
 }
 

--- a/dropdown/api/desktop/dropdown.api
+++ b/dropdown/api/desktop/dropdown.api
@@ -38,7 +38,7 @@ public final class io/androidpoet/dropdown/Divider : io/androidpoet/dropdown/IMe
 public final class io/androidpoet/dropdown/DropDownKt {
 	public static final fun CascadeHeaderItem-iJQMabo (Ljava/lang/String;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun ChildItem-ww6aTOc (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/graphics/vector/ImageVector;JLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
-	public static final fun Dropdown-dJ089pE (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Dropdown-u0eclSw (Landroidx/compose/ui/Modifier;ZLio/androidpoet/dropdown/MenuItem;Lio/androidpoet/dropdown/DropDownMenuColors;JLio/androidpoet/dropdown/MenuPlacement;Lio/androidpoet/dropdown/EnterAnimation;Lio/androidpoet/dropdown/ExitAnimation;Lio/androidpoet/dropdown/Easing;IIFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DropdownContent-FJfuzF0 (Lio/androidpoet/dropdown/MenuItem;Lkotlin/jvm/functions/Function1;Lio/androidpoet/dropdown/DropDownMenuColors;Lkotlin/jvm/functions/Function0;FLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItem (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MenuItemIcon-RPmYEkk (Landroidx/compose/ui/graphics/vector/ImageVector;JLandroidx/compose/runtime/Composer;I)V
@@ -173,5 +173,16 @@ public final class io/androidpoet/dropdown/MenuItem : io/androidpoet/dropdown/IM
 	public final fun setChildren (Ljava/util/List;)V
 	public final fun setIcon (Landroidx/compose/ui/graphics/vector/ImageVector;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/androidpoet/dropdown/MenuPlacement : java/lang/Enum {
+	public static final field Auto Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Down Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field End Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Start Lio/androidpoet/dropdown/MenuPlacement;
+	public static final field Up Lio/androidpoet/dropdown/MenuPlacement;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/androidpoet/dropdown/MenuPlacement;
+	public static fun values ()[Lio/androidpoet/dropdown/MenuPlacement;
 }
 

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDown.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -46,8 +47,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
@@ -58,6 +61,7 @@ import androidx.compose.ui.unit.dp
  * @param menu Represents the menu items to be displayed in the dropdown.
  * @param colors Specifies the colors for the dropdown menu.
  * @param offset Defines the offset of the dropdown from its default position.
+ * @param placement Preferred placement relative to the anchor. Default is Down.
  * @param enter The enter animation for the dropdown content.
  * @param exit The exit animation for the dropdown content.
  * @param easing The easing function for the animation.
@@ -74,6 +78,7 @@ public fun <T : Any> Dropdown(
   menu: MenuItem<T>,
   colors: DropDownMenuColors = dropDownMenuColors(),
   offset: DpOffset = DpOffset.Zero,
+  placement: MenuPlacement = MenuPlacement.Down,
   enter: EnterAnimation = EnterAnimation.FadeIn,
   exit: ExitAnimation = ExitAnimation.FadeOut,
   easing: Easing = Easing.FastOutLinearInEasing,
@@ -85,11 +90,25 @@ public fun <T : Any> Dropdown(
 ) {
   var currentMenu by remember(menu, isOpen) { mutableStateOf(menu) }
 
+  val resolvedOffset = when (placement) {
+    MenuPlacement.Down -> offset
+    MenuPlacement.Up -> DpOffset(offset.x, -width - offset.y)
+    MenuPlacement.End -> {
+      val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+      DpOffset(if (isRtl) -width - offset.x else offset.x, offset.y)
+    }
+    MenuPlacement.Start -> {
+      val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+      DpOffset(if (isRtl) offset.x else -width - offset.x, offset.y)
+    }
+    MenuPlacement.Auto -> offset // Simple auto: just use offset (could enhance with BoxWithConstraints)
+  }
+
   DropdownMenu(
     modifier = modifier.width(width).background(colors.backgroundColor),
     expanded = isOpen,
     onDismissRequest = { onDismiss() },
-    offset = offset,
+    offset = resolvedOffset,
   ) {
     AnimatedContent(targetState = currentMenu, transitionSpec = {
       animateContent(

--- a/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
+++ b/dropdown/src/commonMain/kotlin/io/androidpoet/dropdown/DropDownMenuBuilder.kt
@@ -17,6 +17,22 @@ package io.androidpoet.dropdown
 
 import androidx.compose.ui.graphics.vector.ImageVector
 
+/**
+ * Defines the preferred placement of the dropdown menu relative to its anchor.
+ */
+public enum class MenuPlacement {
+  /** Automatically detect best placement based on available space. */
+  Auto,
+  /** Place below the anchor (default). */
+  Down,
+  /** Place above the anchor. */
+  Up,
+  /** Place to the end (right in LTR, left in RTL). */
+  End,
+  /** Place to the start (left in LTR, right in RTL). */
+  Start,
+}
+
 @DslMarker
 public annotation class MenuDSL
 


### PR DESCRIPTION
## Summary
Introduces the `MenuPlacement` enum and `placement` parameter to control where the dropdown menu appears relative to its anchor.

## Changes
- **New enum `MenuPlacement`** with values: Auto, Down, Up, End, Start
- **New parameter `placement`** on `Dropdown()` composable (default: `MenuPlacement.Down`)
- **Offset resolution** for each placement:
  - Down: standard offset
  - Up: offsets menu above the anchor
  - End: places to the right (LTR) / left (RTL)
  - Start: places to the left (LTR) / right (RTL)
  - Auto: currently falls back to Down (extensible with BoxWithConstraints)
- **RTL-aware** logic for End/Start placements
- API dumps updated
